### PR TITLE
added inputs standardization with standard scaler

### DIFF
--- a/train/eval.py
+++ b/train/eval.py
@@ -15,6 +15,7 @@ import matplotlib.pyplot as plt
 from sklearn.metrics import roc_curve, auc
 import pandas as pd
 from sklearn.model_selection import train_test_split
+from sklearn import preprocessing
 from constraints import ZeroSomeWeights
 from keras.utils.generic_utils import get_custom_objects
 get_custom_objects().update({"ZeroSomeWeights": ZeroSomeWeights})
@@ -114,6 +115,11 @@ if __name__ == "__main__":
     print y_train_val.shape
     print X_test.shape
     print y_test.shape
+    
+    #Normalize
+    if yamlConfig['NormalizeInputs']:
+     scaler = preprocessing.StandardScaler().fit(X_train_val)
+     X_test = scaler.transform(X_test)    
     
     model = load_model(options.inputModel, custom_objects={'ZeroSomeWeights':ZeroSomeWeights})
 

--- a/train/train.py
+++ b/train/train.py
@@ -12,6 +12,7 @@ from callbacks import all_callbacks
 import pandas as pd
 from keras.layers import Input
 from sklearn.model_selection import train_test_split
+from sklearn import preprocessing
 import yaml
 import models
 
@@ -55,7 +56,7 @@ if __name__ == "__main__":
     # Convert to dataframe
     features_df = pd.DataFrame(treeArray,columns=features)
     labels_df = pd.DataFrame(treeArray,columns=labels)
-    
+        
     # Convert to numpy array with correct shape
     features_val = features_df.values
     labels_val = labels_df.values
@@ -66,6 +67,13 @@ if __name__ == "__main__":
     print X_test.shape
     print y_test.shape
 
+
+    #Normalize inputs
+    if yamlConfig['NormalizeInputs']:
+     scaler = preprocessing.StandardScaler().fit(X_train_val)
+     X_train_val = scaler.transform(X_train_val)
+ 
+     
     #from models import three_layer_model
     model = getattr(models, yamlConfig['KerasModel'])
     

--- a/train/train_config_threelayer.yml
+++ b/train/train_config_threelayer.yml
@@ -27,3 +27,4 @@ KerasModel: three_layer_model
 KerasModelRetrain: three_layer_model_constraint
 KerasLoss: categorical_crossentropy
 L1Reg: 0
+NormalizeInputs: 1 

--- a/train/train_config_twolayer.yml
+++ b/train/train_config_twolayer.yml
@@ -17,3 +17,4 @@ KerasModel: two_layer_model
 KerasModelRetrain: two_layer_model_constraint
 KerasLoss: binary_crossentropy
 L1Reg: 0
+NormalizeInputs: 1


### PR DESCRIPTION
The standardization of the inputs for the train sample is optional. To switch it on put "NormalizeInputs: 1" in the model config file. Notice that it is currently ON.

If the option is ON then in the eval.py script the test sample is automatically normalized using the parameters (mean, scale, variance) obtained for the train sample.