### PR TITLE
added binary,ternary,and quantized version of the 3-layer model

### DIFF
--- a/train/eval.py
+++ b/train/eval.py
@@ -23,6 +23,8 @@ from keras.utils.generic_utils import get_custom_objects
 get_custom_objects().update({"ZeroSomeWeights": ZeroSomeWeights})
 import yaml
 from train import parse_config, get_features
+from quantized_layers import Clip, BinaryDense, TernaryDense, QuantizedDense
+from models import binary_tanh, ternary_tanh, quantized_relu
 
 # To turn off GPU
 #os.environ['CUDA_VISIBLE_DEVICES'] = ''
@@ -122,15 +124,22 @@ if __name__ == "__main__":
 
     yamlConfig = parse_config(options.config)
     
-    #if os.path.isdir(options.outputDir):
-    #    raise Exception('output directory must not exists yet')
-    #else:
-    #    os.mkdir(options.outputDir)
+    if os.path.isdir(options.outputDir):
+        raise Exception('output directory must not exists yet')
+    else:
+        os.mkdir(options.outputDir)
 
     X_train_val, X_test, y_train_val, y_test, labels  = get_features(options, yamlConfig)
 
 
-    model = load_model(options.inputModel, custom_objects={'ZeroSomeWeights':ZeroSomeWeights})
+    model = load_model(options.inputModel, custom_objects={'ZeroSomeWeights':ZeroSomeWeights,
+                                                           'BinaryDense': BinaryDense,
+                                                           'TernaryDense': TernaryDense,
+                                                           'QuantizedDense': QuantizedDense,
+                                                           'binary_tanh': binary_tanh,
+                                                           'ternary_tanh': ternary_tanh,
+                                                           'quantized_relu': quantized_relu,
+                                                           'Clip': Clip})
 
     y_predict = makeRoc(X_test, labels, y_test, model, options.outputDir)
     y_test_proba = y_test.argmax(axis=1)

--- a/train/quantized_layers.py
+++ b/train/quantized_layers.py
@@ -1,0 +1,580 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+
+from keras import backend as K
+
+from keras.layers import InputSpec, Layer, Dense, Conv2D, SimpleRNN
+from keras import constraints
+from keras import initializers
+
+from quantized_ops import quantize, clip_through, binarize, ternarize
+
+
+class Clip(constraints.Constraint):
+    def __init__(self, min_value, max_value=None):
+        self.min_value = min_value
+        self.max_value = max_value
+        if not self.max_value:
+            self.max_value = -self.min_value
+        if self.min_value > self.max_value:
+            self.min_value, self.max_value = self.max_value, self.min_value
+
+    def __call__(self, p):
+        return K.clip(p, self.min_value, self.max_value)
+
+    def get_config(self):
+        return {"min_value": self.min_value,
+                "max_value": self.max_value}
+
+
+class BinaryDense(Dense):
+    ''' Binarized Dense layer
+    References: 
+    "BinaryNet: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1" [http://arxiv.org/abs/1602.02830]
+    '''
+    def __init__(self, units, H=1., kernel_lr_multiplier='Glorot', bias_lr_multiplier=None, **kwargs):
+        super(BinaryDense, self).__init__(units, **kwargs)
+        self.H = H
+        self.kernel_lr_multiplier = kernel_lr_multiplier
+        self.bias_lr_multiplier = bias_lr_multiplier
+        
+        super(BinaryDense, self).__init__(units, **kwargs)
+    
+    def build(self, input_shape):
+        assert len(input_shape) >= 2
+        input_dim = input_shape[1]
+
+        if self.H == 'Glorot':
+            self.H = np.float32(np.sqrt(1.5 / (input_dim + self.units)))
+            #print('Glorot H: {}'.format(self.H))
+        if self.kernel_lr_multiplier == 'Glorot':
+            self.kernel_lr_multiplier = np.float32(1. / np.sqrt(1.5 / (input_dim + self.units)))
+            #print('Glorot learning rate multiplier: {}'.format(self.kernel_lr_multiplier))
+            
+        self.kernel_constraint = Clip(-self.H, self.H)
+        self.kernel_initializer = initializers.RandomUniform(-self.H, self.H)
+        self.kernel = self.add_weight(shape=(input_dim, self.units),
+                                     initializer=self.kernel_initializer,
+                                     name='kernel',
+                                     regularizer=self.kernel_regularizer,
+                                     constraint=self.kernel_constraint)
+
+        if self.use_bias:
+            self.lr_multipliers = [self.kernel_lr_multiplier, self.bias_lr_multiplier]
+            self.bias = self.add_weight(shape=(self.output_dim,),
+                                     initializer=self.bias_initializer,
+                                     name='bias',
+                                     regularizer=self.bias_regularizer,
+                                     constraint=self.bias_constraint)
+        else:
+            self.lr_multipliers = [self.kernel_lr_multiplier]
+            self.bias = None
+
+        self.input_spec = InputSpec(min_ndim=2, axes={-1: input_dim})
+        self.built = True
+
+
+    def call(self, inputs):
+        binary_kernel = binarize(self.kernel, H=self.H)
+        output = K.dot(inputs, binary_kernel)
+        if self.use_bias:
+            output = K.bias_add(output, self.bias)
+        if self.activation is not None:
+            output = self.activation(output)
+        return output
+        
+    def get_config(self):
+        config = {'H': self.H,
+                  'kernel_lr_multiplier': self.kernel_lr_multiplier,
+                  'bias_lr_multiplier': self.bias_lr_multiplier}
+        base_config = super(BinaryDense, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+class BinaryConv2D(Conv2D):
+    '''Binarized Convolution2D layer
+    References: 
+    "BinaryNet: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1" [http://arxiv.org/abs/1602.02830]
+    '''
+    def __init__(self, filters, kernel_lr_multiplier='Glorot', 
+                 bias_lr_multiplier=None, H=1., **kwargs):
+        super(BinaryConv2D, self).__init__(filters, **kwargs)
+        self.H = H
+        self.kernel_lr_multiplier = kernel_lr_multiplier
+        self.bias_lr_multiplier = bias_lr_multiplier
+        
+        
+    def build(self, input_shape):
+        if self.data_format == 'channels_first':
+            channel_axis = 1
+        else:
+            channel_axis = -1 
+        if input_shape[channel_axis] is None:
+                raise ValueError('The channel dimension of the inputs '
+                                 'should be defined. Found `None`.')
+
+        input_dim = input_shape[channel_axis]
+        kernel_shape = self.kernel_size + (input_dim, self.filters)
+            
+        base = self.kernel_size[0] * self.kernel_size[1]
+        if self.H == 'Glorot':
+            nb_input = int(input_dim * base)
+            nb_output = int(self.filters * base)
+            self.H = np.float32(np.sqrt(1.5 / (nb_input + nb_output)))
+            #print('Glorot H: {}'.format(self.H))
+            
+        if self.kernel_lr_multiplier == 'Glorot':
+            nb_input = int(input_dim * base)
+            nb_output = int(self.filters * base)
+            self.kernel_lr_multiplier = np.float32(1. / np.sqrt(1.5/ (nb_input + nb_output)))
+            #print('Glorot learning rate multiplier: {}'.format(self.lr_multiplier))
+
+        self.kernel_constraint = Clip(-self.H, self.H)
+        self.kernel_initializer = initializers.RandomUniform(-self.H, self.H)
+        self.kernel = self.add_weight(shape=kernel_shape,
+                                 initializer=self.kernel_initializer,
+                                 name='kernel',
+                                 regularizer=self.kernel_regularizer,
+                                 constraint=self.kernel_constraint)
+
+        if self.use_bias:
+            self.lr_multipliers = [self.kernel_lr_multiplier, self.bias_lr_multiplier]
+            self.bias = self.add_weight((self.output_dim,),
+                                     initializer=self.bias_initializers,
+                                     name='bias',
+                                     regularizer=self.bias_regularizer,
+                                     constraint=self.bias_constraint)
+
+        else:
+            self.lr_multipliers = [self.kernel_lr_multiplier]
+            self.bias = None
+
+        # Set input spec.
+        self.input_spec = InputSpec(ndim=4, axes={channel_axis: input_dim})
+        self.built = True
+
+    def call(self, inputs):
+        binary_kernel = binarize(self.kernel, H=self.H) 
+        outputs = K.conv2d(
+            inputs,
+            binary_kernel,
+            strides=self.strides,
+            padding=self.padding,
+            data_format=self.data_format,
+            dilation_rate=self.dilation_rate)
+
+        if self.use_bias:
+            outputs = K.bias_add(
+                outputs,
+                self.bias,
+                data_format=self.data_format)
+
+        if self.activation is not None:
+            return self.activation(outputs)
+        return outputs
+        
+    def get_config(self):
+        config = {'H': self.H,
+                  'kernel_lr_multiplier': self.kernel_lr_multiplier,
+                  'bias_lr_multiplier': self.bias_lr_multiplier}
+        base_config = super(BinaryConv2D, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+
+
+class TernaryDense(Dense):
+    ''' Ternarized Dense layer
+
+    References: 
+    - [Recurrent Neural Networks with Limited Numerical Precision](http://arxiv.org/abs/1608.06902}
+    - [Ternary Weight Networks](http://arxiv.org/abs/1605.04711)
+    '''
+    def __init__(self, units, H=1., kernel_lr_multiplier='Glorot', bias_lr_multiplier=None, **kwargs):
+        super(TernaryDense, self).__init__(units, **kwargs)
+        self.H = H
+        self.kernel_lr_multiplier = kernel_lr_multiplier
+        self.bias_lr_multiplier = bias_lr_multiplier
+        
+    
+    def build(self, input_shape):
+        assert len(input_shape) >= 2
+        input_dim = input_shape[1]
+
+        if self.H == 'Glorot':
+            self.H = np.float32(np.sqrt(1.5 / (input_dim + self.units)))
+            #print('Glorot H: {}'.format(self.H))
+        if self.kernel_lr_multiplier == 'Glorot':
+            self.kernel_lr_multiplier = np.float32(1. / np.sqrt(1.5 / (input_dim + self.units)))
+            #print('Glorot learning rate multiplier: {}'.format(self.kernel_lr_multiplier))
+            
+        self.kernel_constraint = Clip(-self.H, self.H)
+        self.kernel_initializer = initializers.RandomUniform(-self.H, self.H)
+        self.kernel = self.add_weight(shape=(input_dim, self.units),
+                                     initializer=self.kernel_initializer,
+                                     name='kernel',
+                                     regularizer=self.kernel_regularizer,
+                                     constraint=self.kernel_constraint)
+
+        if self.use_bias:
+            self.lr_multipliers = [self.kernel_lr_multiplier, self.bias_lr_multiplier]
+            self.bias = self.add_weight(shape=(self.output_dim,),
+                                     initializer=self.bias_initializer,
+                                     name='bias',
+                                     regularizer=self.bias_regularizer,
+                                     constraint=self.bias_constraint)
+        else:
+            self.lr_multipliers = [self.kernel_lr_multiplier]
+            self.bias = None
+
+        self.input_spec = InputSpec(min_ndim=2, axes={-1: input_dim})
+        self.built = True
+
+    def call(self, inputs):
+        ternary_kernel = ternarize(self.kernel, H=self.H)
+        output = K.dot(inputs, ternary_kernel)
+        if self.use_bias:
+            output = K.bias_add(output, self.bias)
+        if self.activation is not None:
+            output = self.activation(output)
+        return output
+        
+    def get_config(self):
+        config = {'H': self.H,
+                  'kernel_lr_multiplier': self.kernel_lr_multiplier,
+                  'bias_lr_multiplier': self.bias_lr_multiplier}
+        base_config = super(TernaryDense, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+class TernaryConv2D(Conv2D):
+    '''Ternarized Convolution2D layer
+    References: 
+    - [Recurrent Neural Networks with Limited Numerical Precision](http://arxiv.org/abs/1608.06902}
+    - [Ternary Weight Networks](http://arxiv.org/abs/1605.04711)
+    '''
+    def __init__(self, filters, kernel_lr_multiplier='Glorot', 
+                 bias_lr_multiplier=None, H=1., **kwargs):
+        super(TernaryConv2D, self).__init__(filters, **kwargs)
+        self.H = H
+        self.kernel_lr_multiplier = kernel_lr_multiplier
+        self.bias_lr_multiplier = bias_lr_multiplier
+        
+    def build(self, input_shape):
+        if self.data_format == 'channels_first':
+            channel_axis = 1
+        else:
+            channel_axis = -1 
+        if input_shape[channel_axis] is None:
+                raise ValueError('The channel dimension of the inputs '
+                                 'should be defined. Found `None`.')
+
+        input_dim = input_shape[channel_axis]
+        kernel_shape = self.kernel_size + (input_dim, self.filters)
+            
+        base = self.kernel_size[0] * self.kernel_size[1]
+        if self.H == 'Glorot':
+            nb_input = int(input_dim * base)
+            nb_output = int(self.filters * base)
+            self.H = np.float32(np.sqrt(1.5 / (nb_input + nb_output)))
+            #print('Glorot H: {}'.format(self.H))
+            
+        if self.kernel_lr_multiplier == 'Glorot':
+            nb_input = int(input_dim * base)
+            nb_output = int(self.filters * base)
+            self.kernel_lr_multiplier = np.float32(1. / np.sqrt(1.5/ (nb_input + nb_output)))
+            #print('Glorot learning rate multiplier: {}'.format(self.lr_multiplier))
+
+        self.kernel_constraint = Clip(-self.H, self.H)
+        self.kernel_initializer = initializers.RandomUniform(-self.H, self.H)
+        self.kernel = self.add_weight(shape=kernel_shape,
+                                 initializer=self.kernel_initializer,
+                                 name='kernel',
+                                 regularizer=self.kernel_regularizer,
+                                 constraint=self.kernel_constraint)
+
+        if self.use_bias:
+            self.lr_multipliers = [self.kernel_lr_multiplier, self.bias_lr_multiplier]
+            self.bias = self.add_weight((self.output_dim,),
+                                     initializer=self.bias_initializers,
+                                     name='bias',
+                                     regularizer=self.bias_regularizer,
+                                     constraint=self.bias_constraint)
+
+        else:
+            self.lr_multipliers = [self.kernel_lr_multiplier]
+            self.bias = None
+
+        # Set input spec.
+        self.input_spec = InputSpec(ndim=4, axes={channel_axis: input_dim})
+        self.built = True
+
+    def call(self, inputs):
+        ternary_kernel = ternarize(self.kernel, H=self.H) 
+        outputs = K.conv2d(
+            inputs,
+            ternary_kernel,
+            strides=self.strides,
+            padding=self.padding,
+            data_format=self.data_format,
+            dilation_rate=self.dilation_rate)
+
+        if self.use_bias:
+            outputs = K.bias_add(
+                outputs,
+                self.bias,
+                data_format=self.data_format)
+
+        if self.activation is not None:
+            return self.activation(outputs)
+        return outputs
+        
+    def get_config(self):
+        config = {'H': self.H,
+                  'kernel_lr_multiplier': self.kernel_lr_multiplier,
+                  'bias_lr_multiplier': self.bias_lr_multiplier}
+        base_config = super(TernaryConv2D, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+class TernaryRNN(SimpleRNN):
+    ''' Ternarized RNN layer
+
+    References: 
+    - [Recurrent Neural Networks with Limited Numerical Precision](http://arxiv.org/abs/1608.06902}
+    '''
+    def preprocess_input(self, inputs, training=None):
+        return inputs
+
+    def step(self, inputs, states):
+        if 0 < self.dropout < 1:
+            h = ternarize_dot(inputs * states[1], self.kernel)
+        else:
+            h = ternarize_dot(inputs, self.kernel)
+        if self.bias is not None:
+            h = K.bias_add(h, self.bias)
+
+        prev_output = states[0]
+        if 0 < self.recurrent_dropout < 1:
+            prev_output *= states[2]
+        output = h + ternarize_dot(prev_output, self.recurrent_kernel)
+        if self.activation is not None:
+            output = self.activation(output)
+
+        # Properly set learning phase on output tensor.
+        if 0 < self.dropout + self.recurrent_dropout:
+            output._uses_learning_phase = True
+        return output, [output]
+
+    def get_constants(self, inputs, training=None):
+        constants = []
+        if 0 < self.dropout < 1:
+            input_shape = K.int_shape(inputs)
+            input_dim = input_shape[-1]
+            ones = K.ones_like(K.reshape(inputs[:, 0, 0], (-1, 1)))
+            ones = K.tile(ones, (1, int(input_dim)))
+
+            def dropped_inputs():
+                return K.dropout(ones, self.dropout)
+
+            dp_mask = K.in_train_phase(dropped_inputs,
+                                       ones,
+                                       training=training)
+            constants.append(dp_mask)
+        else:
+            constants.append(K.cast_to_floatx(1.))
+
+        if 0 < self.recurrent_dropout < 1:
+            ones = K.ones_like(K.reshape(inputs[:, 0, 0], (-1, 1)))
+            ones = K.tile(ones, (1, self.units))
+
+            def dropped_inputs():
+                return K.dropout(ones, self.recurrent_dropout)
+            rec_dp_mask = K.in_train_phase(dropped_inputs,
+                                           ones,
+                                           training=training)
+            constants.append(rec_dp_mask)
+        else:
+            constants.append(K.cast_to_floatx(1.))
+        return constants
+
+
+
+class QuantizedDense(Dense):
+    ''' Binarized Dense layer
+    References: 
+    "QuantizedNet: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1" [http://arxiv.org/abs/1602.02830]
+    '''
+    def __init__(self, units, H=1., nb=16, kernel_lr_multiplier='Glorot', bias_lr_multiplier=None, **kwargs):
+        super(QuantizedDense, self).__init__(units, **kwargs)
+        self.H = H
+        self.nb = nb
+        self.kernel_lr_multiplier = kernel_lr_multiplier
+        self.bias_lr_multiplier = bias_lr_multiplier
+        super(QuantizedDense, self).__init__(units, **kwargs)
+    
+    def build(self, input_shape):
+        assert len(input_shape) >= 2
+        input_dim = input_shape[1]
+
+        if self.H == 'Glorot':
+            self.H = np.float32(np.sqrt(1.5 / (input_dim + self.units)))
+            #print('Glorot H: {}'.format(self.H))
+        if self.kernel_lr_multiplier == 'Glorot':
+            self.kernel_lr_multiplier = np.float32(1. / np.sqrt(1.5 / (input_dim + self.units)))
+            #print('Glorot learning rate multiplier: {}'.format(self.kernel_lr_multiplier))
+            
+        self.kernel_constraint = Clip(-self.H, self.H)
+        self.kernel_initializer = initializers.RandomUniform(-self.H, self.H)
+        self.kernel = self.add_weight(shape=(input_dim, self.units),
+                                     initializer=self.kernel_initializer,
+                                     name='kernel',
+                                     regularizer=self.kernel_regularizer,
+                                     constraint=self.kernel_constraint)
+
+        if self.use_bias:
+            self.lr_multipliers = [self.kernel_lr_multiplier, self.bias_lr_multiplier]
+            self.bias = self.add_weight(shape=(self.units,),
+                                     initializer=self.bias_initializer,
+                                     name='bias',
+                                     regularizer=self.bias_regularizer,
+                                     constraint=self.bias_constraint)
+        else:
+            self.lr_multipliers = [self.kernel_lr_multiplier]
+            self.bias = None
+
+        self.input_spec = InputSpec(min_ndim=2, axes={-1: input_dim})
+        self.built = True
+
+
+    def call(self, inputs):
+        quantized_kernel = quantize(self.kernel, nb=self.nb)
+        output = K.dot(inputs, quantized_kernel)
+        if self.use_bias:
+            output = K.bias_add(output, self.bias)
+        if self.activation is not None:
+            output = self.activation(output)
+
+
+        return output
+        
+        
+    def get_config(self):
+        config = {'H': self.H,
+                  'kernel_lr_multiplier': self.kernel_lr_multiplier,
+                  'bias_lr_multiplier': self.bias_lr_multiplier}
+        base_config = super(QuantizedDense, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+class QuantizedConv2D(Conv2D):
+    '''Binarized Convolution2D layer
+    References: 
+    "QuantizedNet: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1" [http://arxiv.org/abs/1602.02830]
+    '''
+    def __init__(self, filters, kernel_regularizer=None,activity_regularizer=None, kernel_lr_multiplier='Glorot',
+                 bias_lr_multiplier=None, H=1., nb=16,  **kwargs):
+        super(QuantizedConv2D, self).__init__(filters, **kwargs)
+        self.H = H
+        self.nb = nb
+        self.kernel_lr_multiplier = kernel_lr_multiplier
+        self.bias_lr_multiplier = bias_lr_multiplier
+        self.activity_regularizer =activity_regularizer
+        self.kernel_regularizer = kernel_regularizer
+        
+    def build(self, input_shape):
+        if self.data_format == 'channels_first':
+            channel_axis = 1
+        else:
+            channel_axis = -1 
+        if input_shape[channel_axis] is None:
+                raise ValueError('The channel dimension of the inputs '
+                                 'should be defined. Found `None`.')
+
+        input_dim = input_shape[channel_axis]
+        kernel_shape = self.kernel_size + (input_dim, self.filters)
+            
+        base = self.kernel_size[0] * self.kernel_size[1]
+        if self.H == 'Glorot':
+            nb_input = int(input_dim * base)
+            nb_output = int(self.filters * base)
+            self.H = np.float32(np.sqrt(1.5 / (nb_input + nb_output)))
+            #print('Glorot H: {}'.format(self.H))
+            
+        if self.kernel_lr_multiplier == 'Glorot':
+            nb_input = int(input_dim * base)
+            nb_output = int(self.filters * base)
+            self.kernel_lr_multiplier = np.float32(1. / np.sqrt(1.5/ (nb_input + nb_output)))
+            #print('Glorot learning rate multiplier: {}'.format(self.lr_multiplier))
+
+        self.kernel_constraint = Clip(-self.H, self.H)
+        self.kernel_initializer = initializers.RandomUniform(-self.H, self.H)
+        #self.bias_initializer = initializers.RandomUniform(-self.H, self.H)
+        self.kernel = self.add_weight(shape=kernel_shape,
+                                 initializer=self.kernel_initializer,
+                                 name='kernel',
+                                 regularizer=self.kernel_regularizer,
+                                 constraint=self.kernel_constraint)
+
+        if self.use_bias:
+            self.lr_multipliers = [self.kernel_lr_multiplier, self.bias_lr_multiplier]
+            self.bias = self.add_weight((self.filters,),
+                                     initializer=self.bias_initializer,
+                                     name='bias',
+                                     regularizer=self.bias_regularizer,
+                                     constraint=self.bias_constraint)
+
+        else:
+            self.lr_multipliers = [self.kernel_lr_multiplier]
+            self.bias = None
+
+        # Set input spec.
+        self.input_spec = InputSpec(ndim=4, axes={channel_axis: input_dim})
+        self.built = True
+
+    def call(self, inputs):
+        quantized_kernel = quantize(self.kernel, nb=self.nb)
+
+        inverse_kernel_lr_multiplier = 1./self.kernel_lr_multiplier
+        inputs_qnn_gradient = (inputs - (1. - 1./inverse_kernel_lr_multiplier) * K.stop_gradient(inputs))\
+                  * inverse_kernel_lr_multiplier
+
+        outputs_qnn_gradient = K.conv2d(
+            inputs_qnn_gradient,
+            quantized_kernel,
+            strides=self.strides,
+            padding=self.padding,
+            data_format=self.data_format,
+            dilation_rate=self.dilation_rate)
+
+        outputs = (outputs_qnn_gradient - (1. - 1./self.kernel_lr_multiplier) * K.stop_gradient(outputs_qnn_gradient))\
+                  * self.kernel_lr_multiplier
+
+
+        #outputs = outputs*K.mean(K.abs(self.kernel))
+
+        if self.use_bias:
+            outputs = K.bias_add(
+                outputs,
+                self.bias,
+                data_format=self.data_format)
+
+        if self.activation is not None:
+            return self.activation(outputs)
+
+        return outputs
+        
+    def get_config(self):
+        config = {'H': self.H,
+                  'kernel_lr_multiplier': self.kernel_lr_multiplier,
+                  'bias_lr_multiplier': self.bias_lr_multiplier}
+        base_config = super(QuantizedConv2D, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+# Aliases
+BinaryConvolution2D = BinaryConv2D
+TernaryConvolution2D = TernaryConv2D
+QuantizedConvolution2D = QuantizedConv2D
+
+
+

--- a/train/quantized_ops.py
+++ b/train/quantized_ops.py
@@ -1,0 +1,270 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+import keras.backend as K
+import tensorflow as tf
+import numpy as np
+
+def round_through(x):
+    '''Element-wise rounding to the closest integer with full gradient propagation.
+    A trick from [Sergey Ioffe](http://stackoverflow.com/a/36480182)
+    '''
+    rounded = K.round(x)
+    return x + K.stop_gradient(rounded - x)
+
+
+def _hard_sigmoid(x):
+    '''Hard sigmoid different from the more conventional form (see definition of K.hard_sigmoid).
+
+    # Reference:
+    - [BinaryNet: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1, Courbariaux et al. 2016](http://arxiv.org/abs/1602.02830}
+
+    '''
+    x = (0.5 * x) + 0.5
+    return K.clip(x, 0, 1)
+
+
+def binary_sigmoid(x):
+    '''Binary hard sigmoid for training binarized neural network.
+
+    # Reference:
+    - [BinaryNet: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1, Courbariaux et al. 2016](http://arxiv.org/abs/1602.02830}
+
+    '''
+    return round_through(_hard_sigmoid(x))
+
+
+def binary_tanh(x):
+    '''Binary hard sigmoid for training binarized neural network.
+     The neurons' activations binarization function
+     It behaves like the sign function during forward propagation
+     And like:
+        hard_tanh(x) = 2 * _hard_sigmoid(x) - 1 
+        clear gradient when |x| > 1 during back propagation
+
+    # Reference:
+    - [BinaryNet: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1, Courbariaux et al. 2016](http://arxiv.org/abs/1602.02830}
+
+    '''
+    return 2 * round_through(_hard_sigmoid(x)) - 1
+
+
+def binarize(W, H=1):
+    '''The weights' binarization function, 
+
+    # Reference:
+    - [BinaryNet: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1, Courbariaux et al. 2016](http://arxiv.org/abs/1602.02830}
+
+    '''
+    # [-H, H] -> -H or H
+    Wb = H * binary_tanh(W / H)
+    return Wb
+
+
+def _mean_abs(x, axis=None, keepdims=False):
+    return K.stop_gradient(K.mean(K.abs(x), axis=axis, keepdims=keepdims))
+
+    
+def xnorize(W, H=1., axis=None, keepdims=False):
+    Wb = binarize(W, H)
+    Wa = _mean_abs(W, axis, keepdims)
+    
+    return Wa, Wb
+    
+
+
+def clip_through(x, min_val, max_val):
+    '''Element-wise clipping with gradient propagation
+    Analogue to round_through
+    '''
+    clipped = K.clip(x, min_val, max_val)
+    clipped_through= x + K.stop_gradient(clipped-x)
+    return clipped_through 
+
+
+def clip_through(x, min, max):
+    '''Element-wise rounding to the closest integer with full gradient propagation.
+    A trick from [Sergey Ioffe](http://stackoverflow.com/a/36480182)
+    '''
+    clipped = K.clip(x,min,max)
+    return x + K.stop_gradient(clipped - x)
+
+
+
+
+
+def quantize(W, nb = 16, clip_through=False):
+
+    '''The weights' binarization function, 
+
+    # Reference:
+    - [QuantizedNet: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1, Courbariaux et al. 2016](http://arxiv.org/abs/1602.02830}
+
+    '''
+
+    non_sign_bits = nb-1
+    m = pow(2,non_sign_bits)
+    #W = tf.Print(W,[W],summarize=20)
+    if clip_through:
+        Wq = clip_through(round_through(W*m),-m,m-1)/m
+    else:
+        Wq = K.clip(round_through(W*m),-m,m-1)/m
+    #Wq = tf.Print(Wq,[Wq],summarize=20)
+    return Wq
+
+
+def quantized_relu(W, nb=16):
+
+    '''The weights' binarization function, 
+
+    # Reference:
+    - [QuantizedNet: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1, Courbariaux et al. 2016](http://arxiv.org/abs/1602.02830}
+
+    '''
+    #non_sign_bits = nb-1
+    #m = pow(2,non_sign_bits)
+    #Wq = K.clip(round_through(W*m),0,m-1)/m
+
+    nb_bits = nb
+    Wq = K.clip(2. * (round_through(_hard_sigmoid(W) * pow(2, nb_bits)) / pow(2, nb_bits)) - 1., 0,
+                1 - 1.0 / pow(2, nb_bits - 1))
+    return Wq
+
+
+def quantized_tanh(W, nb=16):
+
+    '''The weights' binarization function,
+
+    # Reference:
+    - [QuantizedNet: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1, Courbariaux et al. 2016](http://arxiv.org/abs/1602.02830}
+
+    '''
+    non_sign_bits = nb-1
+    m = pow(2,non_sign_bits)
+    #W = tf.Print(W,[W],summarize=20)
+    Wq = K.clip(round_through(W*m),-m,m-1)/m
+    #Wq = tf.Print(Wq,[Wq],summarize=20)
+    return Wq
+
+def quantized_leakyrelu(W, nb=16, alpha=0.1):
+
+    '''The weights' binarization function, 
+
+    # Reference:
+    - [QuantizedNet: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1, Courbariaux et al. 2016](http://arxiv.org/abs/1602.02830}
+
+    '''
+    if alpha != 0.:
+        negative_part = tf.nn.relu(-W)
+    W = tf.nn.relu(W)
+    if alpha != 0.:
+        alpha = tf.cast(tf.convert_to_tensor(alpha), W.dtype.base_dtype)
+        W -= alpha * negative_part
+
+    non_sign_bits = nb-1
+    m = pow(2,non_sign_bits)
+    #W = tf.Print(W,[W],summarize=20)
+    Wq = clip_through(round_through(W*m),-m,m-1)/m
+    #Wq = tf.Print(Wq,[Wq],summarize=20)
+
+    return Wq
+
+def quantized_maxrelu(W, nb=16):
+
+    '''The weights' binarization function, 
+
+    # Reference:
+    - [QuantizedNet: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1, Courbariaux et al. 2016](http://arxiv.org/abs/1602.02830}
+
+    '''
+    non_sign_bits = nb-1
+    max_ = tf.reduce_max((W))
+    #max_ = tf.Print(max_,[max_])
+    max__ = tf.pow(2.0,tf.ceil(tf.log(max_)/tf.log(tf.cast(tf.convert_to_tensor(2.0), W.dtype.base_dtype))))
+    #max__ = tf.Print(max__,[max__])
+    m = pow(2,non_sign_bits)
+    #W = tf.Print(W,[W],summarize=20)
+    Wq = max__*clip_through(round_through(W/max__*(m)),0,m-1)/(m)
+    #Wq = tf.Print(Wq,[Wq],summarize=20)
+
+    return Wq
+
+def quantized_leakymaxrelu(W, nb=16, alpha=0.1):
+
+    '''The weights' binarization function, 
+
+    # Reference:
+    - [QuantizedNet: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1, Courbariaux et al. 2016](http://arxiv.org/abs/1602.02830}
+
+    '''
+    if alpha != 0.:
+        negative_part = tf.nn.relu(-W)
+    W = tf.nn.relu(W)
+    if alpha != 0.:
+        alpha = tf.cast(tf.convert_to_tensor(alpha), W.dtype.base_dtype)
+        W -= alpha * negative_part
+
+    max_ = tf.reduce_max((W))
+    #max_ = tf.Print(max_,[max_])
+    max__ = tf.pow(2.0,tf.ceil(tf.log(max_)/tf.log(tf.cast(tf.convert_to_tensor(2.0), W.dtype.base_dtype))))
+    #max__ = tf.Print(max__,[max__])
+
+    non_sign_bits = nb-1
+    m = pow(2,non_sign_bits)
+    #W = tf.Print(W,[W],summarize=20)
+    Wq = max__* clip_through(round_through(W/max__*m),-m,m-1)/m
+    #Wq = tf.Print(Wq,[Wq],summarize=20)
+
+    return Wq
+
+    
+def xnorize_qnn(W, H=1., axis=None, keepdims=False):
+    Wb = quantize(W, H)
+    Wa = _mean_abs(W, axis, keepdims)
+    
+    return Wa, Wb
+
+def switch(condition, t, e):
+    if K.backend() == 'tensorflow':
+        import tensorflow as tf
+        return tf.where(condition, t, e)
+    elif K.backend() == 'theano':
+        import theano.tensor as tt
+        return tt.switch(condition, t, e)
+
+
+def _ternarize(W, H=1):
+    '''The weights' ternarization function, 
+
+    # References:
+    - [Recurrent Neural Networks with Limited Numerical Precision](http://arxiv.org/abs/1608.06902)
+    - [Ternary Weight Networks](http://arxiv.org/abs/1605.04711)
+    '''
+    W /= H
+
+    ones = K.ones_like(W)
+    zeros = K.zeros_like(W)
+    Wt = switch(W > 0.5, ones, switch(W <= -0.5, -ones, zeros))
+
+    Wt *= H
+
+    return Wt
+
+
+def ternarize(W, H=1):
+    '''The weights' ternarization function, 
+
+    # References:
+    - [Recurrent Neural Networks with Limited Numerical Precision](http://arxiv.org/abs/1608.06902)
+    - [Ternary Weight Networks](http://arxiv.org/abs/1605.04711)
+    '''
+    Wt = _ternarize(W, H)
+    return W + K.stop_gradient(Wt - W)
+
+
+def ternarize_dot(x, W):
+    '''For RNN (maybe Dense or Conv too). 
+    Refer to 'Recurrent Neural Networks with Limited Numerical Precision' Section 3.1
+    '''
+    Wt = _ternarize(W)
+    return K.dot(x, W) + K.stop_gradient(K.dot(x, Wt - W))
+    

--- a/train/train.py
+++ b/train/train.py
@@ -99,6 +99,14 @@ def get_features(options, yamlConfig):
         X_train_val = scaler.transform(X_train_val)
         X_test = scaler.transform(X_test)
 
+    #Normalize inputs
+    if yamlConfig['NormalizeInputs'] and yamlConfig['InputType']!='Conv1D' and yamlConfig['InputType']!='Conv2D' and yamlConfig['KerasLoss']=='squared_hinge':
+        scaler = preprocessing.MinMaxScaler().fit(X_train_val)
+        X_train_val = scaler.transform(X_train_val)
+        X_test = scaler.transform(X_test)
+        y_train_val = y_train_val * 2 - 1
+        y_test = y_test * 2 - 1
+        
     #Normalize conv inputs
     if yamlConfig['NormalizeInputs'] and yamlConfig['InputType']=='Conv1D':
         reshape_X_train_val = X_train_val.reshape(X_train_val.shape[0]*X_train_val.shape[1],X_train_val.shape[2])
@@ -156,5 +164,5 @@ if __name__ == "__main__":
                             lr_minimum=0.0000001,
                             outputDir=options.outputDir)
 
-    keras_model.fit(X_train_val, y_train_val, batch_size = 1024, epochs = 200,
+    keras_model.fit(X_train_val, y_train_val, batch_size = 1024, epochs = 100,
                     validation_split = 0.25, shuffle = True, callbacks = callbacks.callbacks)

--- a/train/train_config_threelayer_binary.yml
+++ b/train/train_config_threelayer_binary.yml
@@ -1,0 +1,31 @@
+Inputs:
+    - j_zlogz
+    - j_c1_b0_mmdt
+    - j_c1_b1_mmdt
+    - j_c1_b2_mmdt
+    - j_c2_b1_mmdt
+    - j_c2_b2_mmdt
+    - j_d2_b1_mmdt
+    - j_d2_b2_mmdt
+    - j_d2_a1_b1_mmdt
+    - j_d2_a1_b2_mmdt
+    - j_m2_b1_mmdt
+    - j_m2_b2_mmdt
+    - j_n2_b1_mmdt
+    - j_n2_b2_mmdt
+    - j_mass_mmdt
+    - j_multiplicity
+    
+Labels:
+    - j_g
+    - j_q
+    - j_w
+    - j_z
+    - j_t
+    
+KerasModel: three_layer_model_binary
+KerasModelRetrain: three_layer_model_constraint
+KerasLoss: squared_hinge
+L1Reg: 0.0001
+NormalizeInputs: 1 
+InputType: Dense

--- a/train/train_config_threelayer_qnn.yml
+++ b/train/train_config_threelayer_qnn.yml
@@ -1,0 +1,31 @@
+Inputs:
+    - j_zlogz
+    - j_c1_b0_mmdt
+    - j_c1_b1_mmdt
+    - j_c1_b2_mmdt
+    - j_c2_b1_mmdt
+    - j_c2_b2_mmdt
+    - j_d2_b1_mmdt
+    - j_d2_b2_mmdt
+    - j_d2_a1_b1_mmdt
+    - j_d2_a1_b2_mmdt
+    - j_m2_b1_mmdt
+    - j_m2_b2_mmdt
+    - j_n2_b1_mmdt
+    - j_n2_b2_mmdt
+    - j_mass_mmdt
+    - j_multiplicity
+    
+Labels:
+    - j_g
+    - j_q
+    - j_w
+    - j_z
+    - j_t
+    
+KerasModel: three_layer_model_qnn
+KerasModelRetrain: three_layer_model_constraint
+KerasLoss: squared_hinge
+L1Reg: 0.0001
+NormalizeInputs: 1 
+InputType: Dense

--- a/train/train_config_threelayer_ternary.yml
+++ b/train/train_config_threelayer_ternary.yml
@@ -1,0 +1,31 @@
+Inputs:
+    - j_zlogz
+    - j_c1_b0_mmdt
+    - j_c1_b1_mmdt
+    - j_c1_b2_mmdt
+    - j_c2_b1_mmdt
+    - j_c2_b2_mmdt
+    - j_d2_b1_mmdt
+    - j_d2_b2_mmdt
+    - j_d2_a1_b1_mmdt
+    - j_d2_a1_b2_mmdt
+    - j_m2_b1_mmdt
+    - j_m2_b2_mmdt
+    - j_n2_b1_mmdt
+    - j_n2_b2_mmdt
+    - j_mass_mmdt
+    - j_multiplicity
+    
+Labels:
+    - j_g
+    - j_q
+    - j_w
+    - j_z
+    - j_t
+    
+KerasModel: three_layer_model_ternary
+KerasModelRetrain: three_layer_model_constraint
+KerasLoss: squared_hinge
+L1Reg: 0.0001
+NormalizeInputs: 1 
+InputType: Dense


### PR DESCRIPTION
Inspired from the MNIST-mpl example here:

https://github.com/DingKe/nn_playground/blob/master/binarynet/mnist_mlp.py

that uses fully connected layers + binary (or ternary) activation function + batch normalization.

Here the references:

binary networks: https://arxiv.org/abs/1602.02830
ternary networks: https://arxiv.org/abs/1605.04711
quantized networks: https://arxiv.org/abs/1609.07061

For quantized networks, one in principle can set whatever precision for both weights and activations. I gave a try with 4 bits as set in the PR but I can't reproduce what I get with binary or ternary. This needs to be understood.

In general, I apply a MinMaxScaler to the inputs first and re-categorize the classes such that

0 --> -1
1 --> 1

I have also changed for these cases the loss function from categorical_crossentropy to squared_hinge as used in the MNIST example. 

There is a loss of performance on the AUC of about 10%:

![training_bnn](https://user-images.githubusercontent.com/5583089/40817230-f029045e-6516-11e8-8447-fe48c65dcf2c.png)

![training_tnn](https://user-images.githubusercontent.com/5583089/40817238-f93eff26-6516-11e8-9786-835542da9b20.png)

Need to understand also why the final weights are not binarized (or ternarized). And more tests are needed to understand the over training visible in the validation loss function versus epoch and/or if a bigger network would actually gain more from the binarization.

The batch normalization layer is a nice addition to the hls4ml library but I would not expect it to be fundamental for a binary/ternary network case where activation functions and weights are already constrained, although it is used in the references.
